### PR TITLE
LED full color at 100%

### DIFF
--- a/sdk/src/java/org/lineageos/internal/notification/LineageBatteryLights.java
+++ b/sdk/src/java/org/lineageos/internal/notification/LineageBatteryLights.java
@@ -165,7 +165,7 @@ public final class LineageBatteryLights {
             }
         } else if (status == BatteryManager.BATTERY_STATUS_CHARGING
                 || status == BatteryManager.BATTERY_STATUS_FULL) {
-            if (status == BatteryManager.BATTERY_STATUS_FULL || level >= 90) {
+            if (status == BatteryManager.BATTERY_STATUS_FULL || level >= 100) {
                 // Battery is full or charging and nearly full.
                 ledValues.setColor(mBatteryFullARGB);
                 ledValues.setSolid();


### PR DESCRIPTION
Change-Id: Id96d4bb071e512f42723dc5c641f135b4f5ca4e4

Maybe smart charging would be an argument to leave it, but best battery life is charging until 80%. And everbody misses the moment at 90 or more percent when the led changes the color. So, would be great if it's find its ways into the official OptLos.